### PR TITLE
Added a task list to the right side of the screen that is populated

### DIFF
--- a/Project_Robo/Assets/Cinemachine/CinemachineExamples.unitypackage.meta
+++ b/Project_Robo/Assets/Cinemachine/CinemachineExamples.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 435e0ab87d10d1d46966abe3e1b854db
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Project_Robo/Assets/Prefabs/PuzzleObject.prefab
+++ b/Project_Robo/Assets/Prefabs/PuzzleObject.prefab
@@ -47,8 +47,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   selfObject: {fileID: 0}
   placementCube: {fileID: 8632859345123192786}
+  taskTextPrefab: {fileID: 8025588474947579541, guid: 2b277a30c79b07648bff32e8b46ee8c9, type: 3}
   puzzleID: 0
-  collision: {fileID: 0}
+  taskName: Observe the Monitor
+  taskHolder: {fileID: 0}
+  taskText: {fileID: 0}
+  cleared: 0
+  nearThis: 0
 --- !u!65 &7569359348855922315
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Project_Robo/Assets/Prefabs/PuzzleObjectExampleText.prefab
+++ b/Project_Robo/Assets/Prefabs/PuzzleObjectExampleText.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9098829441999214357
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8392960832928126535}
+  - component: {fileID: 980409755566563905}
+  - component: {fileID: 8025588474947579541}
+  m_Layer: 5
+  m_Name: PuzzleObjectExampleText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8392960832928126535
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9098829441999214357}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 880, y: 440}
+  m_SizeDelta: {x: 600, y: 50}
+  m_Pivot: {x: 1, y: 1}
+--- !u!222 &980409755566563905
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9098829441999214357}
+  m_CullTransparentMesh: 1
+--- !u!114 &8025588474947579541
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9098829441999214357}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 40
+    m_Alignment: 2
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: This is a Test

--- a/Project_Robo/Assets/Prefabs/PuzzleObjectExampleText.prefab.meta
+++ b/Project_Robo/Assets/Prefabs/PuzzleObjectExampleText.prefab.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 1e24085edff8e4e499582d8dcf099510
-DefaultImporter:
+guid: 2b277a30c79b07648bff32e8b46ee8c9
+PrefabImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Project_Robo/Assets/Prefabs/PuzzleReadyCanvas.prefab
+++ b/Project_Robo/Assets/Prefabs/PuzzleReadyCanvas.prefab
@@ -34,7 +34,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 28.99997, y: -5.0000153}
+  m_AnchoredPosition: {x: 28.99997, y: 380}
   m_SizeDelta: {x: 1250, y: 500}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1030779319
@@ -58,7 +58,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_Color: {r: 0.5509434, g: 1, b: 0.6067335, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -79,6 +79,41 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Press "E" to display this puzzle
+--- !u!1 &3720324452772419925
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7591369884324081962}
+  m_Layer: 5
+  m_Name: TaskListHolder
+  m_TagString: TaskList
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7591369884324081962
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3720324452772419925}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 9084769514669396345}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -910, y: -490}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 1, y: 1}
 --- !u!1 &9084769514669396341
 GameObject:
   m_ObjectHideFlags: 0
@@ -111,6 +146,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1030779320}
+  - {fileID: 7591369884324081962}
   - {fileID: 9084769516200461147}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -194,13 +230,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerId: 0
+  puzzleObjects:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   puzzles:
-  - {fileID: 9084769515900574031}
-  - {fileID: 9084769515332168713}
   - {fileID: 3865213448081756936}
   - {fileID: 4526369151850074799}
+  - {fileID: 9084769515900574031}
   - {fileID: 5628576186986144509}
   - {fileID: 646847907996524501}
+  - {fileID: 9084769515332168713}
   currentPuzzle: 0
   holder: {fileID: 9084769516200461144}
   puzzleNearText: {fileID: 0}
@@ -239,7 +282,7 @@ RectTransform:
   m_LocalScale: {x: 0.5, y: 0.5, z: 1}
   m_Children: []
   m_Father: {fileID: 9084769516200461147}
-  m_RootOrder: 3
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -450,15 +493,15 @@ RectTransform:
   m_LocalScale: {x: 0.7932539, y: 0.7932539, z: 0.7932539}
   m_Children:
   - {fileID: 9084769515768295374}
-  - {fileID: 9084769515900574030}
-  - {fileID: 9084769515332168712}
-  - {fileID: 9084769515391746178}
   - {fileID: 3865213448081756937}
   - {fileID: 4526369151850074798}
+  - {fileID: 9084769515900574030}
   - {fileID: 5628576186986144508}
   - {fileID: 646847907996524500}
+  - {fileID: 9084769515332168712}
+  - {fileID: 9084769515391746178}
   m_Father: {fileID: 9084769514669396345}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -482,7 +525,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5628576186754715172, guid: 3091431b85e0f4c4bbd12134d660e535, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5628576186754715172, guid: 3091431b85e0f4c4bbd12134d660e535, type: 3}
       propertyPath: m_AnchorMax.x
@@ -562,14 +605,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3091431b85e0f4c4bbd12134d660e535, type: 3}
---- !u!1 &5628576186986144509 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5628576186754715173, guid: 3091431b85e0f4c4bbd12134d660e535, type: 3}
-  m_PrefabInstance: {fileID: 305458392}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &5628576186986144508 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5628576186754715172, guid: 3091431b85e0f4c4bbd12134d660e535, type: 3}
+  m_PrefabInstance: {fileID: 305458392}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5628576186986144509 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5628576186754715173, guid: 3091431b85e0f4c4bbd12134d660e535, type: 3}
   m_PrefabInstance: {fileID: 305458392}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &317703885
@@ -593,7 +636,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 646847908221131033, guid: 39c0a0888a6c3e543aba7327e93341e5, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 646847908221131033, guid: 39c0a0888a6c3e543aba7327e93341e5, type: 3}
       propertyPath: m_AnchorMax.x
@@ -696,7 +739,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3865213446992266652, guid: bf728e7955dd5fd4d890a591cacde9a6, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3865213446992266652, guid: bf728e7955dd5fd4d890a591cacde9a6, type: 3}
       propertyPath: m_AnchorMax.x
@@ -776,14 +819,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bf728e7955dd5fd4d890a591cacde9a6, type: 3}
---- !u!1 &3865213448081756936 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3865213446992266653, guid: bf728e7955dd5fd4d890a591cacde9a6, type: 3}
-  m_PrefabInstance: {fileID: 1089492629}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &3865213448081756937 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3865213446992266652, guid: bf728e7955dd5fd4d890a591cacde9a6, type: 3}
+  m_PrefabInstance: {fileID: 1089492629}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &3865213448081756936 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3865213446992266653, guid: bf728e7955dd5fd4d890a591cacde9a6, type: 3}
   m_PrefabInstance: {fileID: 1089492629}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1185125974
@@ -803,7 +846,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4526369152967689464, guid: fae570ec0e3efa44b9503047400cb7fb, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4526369152967689464, guid: fae570ec0e3efa44b9503047400cb7fb, type: 3}
       propertyPath: m_AnchorMax.x
@@ -910,7 +953,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1878548382264114822, guid: 5b4360594d373f240abbc32765203e29, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 1878548382264114822, guid: 5b4360594d373f240abbc32765203e29, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1053,7 +1096,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1260361970617062835, guid: 0567f785258f9cb44a3eec9cb64a4278, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1260361970617062835, guid: 0567f785258f9cb44a3eec9cb64a4278, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1157,13 +1200,13 @@ PrefabInstance:
       objectReference: {fileID: 9084769515391746181}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0567f785258f9cb44a3eec9cb64a4278, type: 3}
---- !u!1 &9084769515900574031 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1260361970617062834, guid: 0567f785258f9cb44a3eec9cb64a4278, type: 3}
-  m_PrefabInstance: {fileID: 8029391697408920829}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &9084769515900574030 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1260361970617062835, guid: 0567f785258f9cb44a3eec9cb64a4278, type: 3}
+  m_PrefabInstance: {fileID: 8029391697408920829}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &9084769515900574031 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1260361970617062834, guid: 0567f785258f9cb44a3eec9cb64a4278, type: 3}
   m_PrefabInstance: {fileID: 8029391697408920829}
   m_PrefabAsset: {fileID: 0}

--- a/Project_Robo/Assets/Scenes/PuzzleScene.unity
+++ b/Project_Robo/Assets/Scenes/PuzzleScene.unity
@@ -151,7 +151,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &152169463
 GameObject:
@@ -208,7 +208,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 152169463}
-  m_LocalRotation: {x: 0.44135332, y: 0.00000041262754, z: -0.0000002292613, w: 0.89733344}
+  m_LocalRotation: {x: 0.4413535, y: 0.00000041262754, z: -0.00000022926137, w: 0.8973334}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -380,63 +380,6 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1001 &313974891
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1797811649}
-    m_Modifications:
-    - target: {fileID: 4441008091133875153, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
-      propertyPath: m_Name
-      value: RobotParticleSystem
-      objectReference: {fileID: 0}
-    - target: {fileID: 4987200496752931475, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4987200496752931475, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4987200496752931475, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.822
-      objectReference: {fileID: 0}
-    - target: {fileID: 4987200496752931475, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4987200496752931475, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 4987200496752931475, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 4987200496752931475, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4987200496752931475, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4987200496752931475, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -270
-      objectReference: {fileID: 0}
-    - target: {fileID: 4987200496752931475, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4987200496752931475, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2a0fbc7449aabba4aaa3480cc53cdaf0, type: 3}
 --- !u!1 &323291244 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 646847908221131032, guid: 39c0a0888a6c3e543aba7327e93341e5, type: 3}
@@ -447,6 +390,71 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 646847908221131033, guid: 39c0a0888a6c3e543aba7327e93341e5, type: 3}
   m_PrefabInstance: {fileID: 832847768}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &377825753
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 919132147522786388, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: cam
+      value: 
+      objectReference: {fileID: 1994886547}
+    - target: {fileID: 3469034373086512442, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 3469034373086512442, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_TagString
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d7f17621c30525b429ad23480d633e51, type: 3}
 --- !u!1001 &422617578
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -456,7 +464,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_LocalPosition.x
@@ -584,90 +592,8 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &460713635
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 460713636}
-  - component: {fileID: 460713637}
-  - component: {fileID: 460713638}
-  - component: {fileID: 460713639}
-  m_Layer: 0
-  m_Name: Player
-  m_TagString: Player
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &460713636
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 460713635}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 5.58, z: -7.91}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1797811649}
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &460713637
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 460713635}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 193c8b65d38fe6d428c99fd7ea8c3c82, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  controller: {fileID: 460713638}
-  speed: 6
-  turnSmoothTime: 0.3
-  cam: {fileID: 963194228}
-  playerId: 0
---- !u!143 &460713638
-CharacterController:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 460713635}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Height: 2
-  m_Radius: 0.5
-  m_SlopeLimit: 45
-  m_StepOffset: 0.3
-  m_SkinWidth: 0.08
-  m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &460713639
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 460713635}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53a309fb2d72bd64fbce4b5334a93aa3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  playerId: 0
 --- !u!1 &468209906
 GameObject:
   m_ObjectHideFlags: 0
@@ -696,7 +622,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!43 &554256276
 Mesh:
@@ -1173,7 +1099,7 @@ Transform:
   m_LocalScale: {x: 3, y: 3, z: 3}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &705507993
 GameObject:
@@ -1402,7 +1328,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 810834811}
-  m_LocalRotation: {x: 0.4250239, y: -0, z: -0, w: 0.9051822}
+  m_LocalRotation: {x: 0.42502403, y: -0, z: -0, w: 0.9051821}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1465,7 +1391,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 825130883}
-  m_LocalRotation: {x: 0.5138035, y: 0.0029572253, z: -0.0017708857, w: 0.85790104}
+  m_LocalRotation: {x: 0.5138034, y: 0.0029562502, z: -0.0017703014, w: 0.8579011}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1590,117 +1516,6 @@ PrefabInstance:
       objectReference: {fileID: 9084769515116887269}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 39c0a0888a6c3e543aba7327e93341e5, type: 3}
---- !u!1 &963194225
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 963194228}
-  - component: {fileID: 963194227}
-  - component: {fileID: 963194226}
-  - component: {fileID: 963194229}
-  m_Layer: 0
-  m_Name: Main Camera
-  m_TagString: MainCamera
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!81 &963194226
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 963194225}
-  m_Enabled: 1
---- !u!20 &963194227
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 963194225}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.01
-  far clip plane: 5000
-  field of view: 40
-  orthographic: 0
-  orthographic size: 10
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!4 &963194228
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 963194225}
-  m_LocalRotation: {x: 0.51380336, y: 0.002958362, z: -0.0017717851, w: 0.85790104}
-  m_LocalPosition: {x: 0, y: 19.58, z: -17.91}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &963194229
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 963194225}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_ShowDebugText: 0
-  m_ShowCameraFrustum: 1
-  m_IgnoreTimeScale: 0
-  m_WorldUpOverride: {fileID: 0}
-  m_UpdateMethod: 2
-  m_DefaultBlend:
-    m_Style: 1
-    m_Time: 2
-  m_CustomBlends: {fileID: 0}
-  m_CameraCutEvent:
-    m_PersistentCalls:
-      m_Calls: []
-  m_CameraActivatedEvent:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!1001 &1027246184
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1714,7 +1529,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6222184559087159437, guid: fb09df0ac017da342b4cf442b5df4126, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 6222184559087159437, guid: fb09df0ac017da342b4cf442b5df4126, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2190,68 +2005,117 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1001 &1797811648
-PrefabInstance:
+--- !u!1 &1994886546
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 460713636}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -5.58
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.33999968
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-      propertyPath: m_Name
-      value: Bit-Bot
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
---- !u!4 &1797811649 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 1219aa72a96e8e843bb4e3b778908735, type: 3}
-  m_PrefabInstance: {fileID: 1797811648}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1994886547}
+  - component: {fileID: 1994886550}
+  - component: {fileID: 1994886549}
+  - component: {fileID: 1994886548}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1994886547
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1994886546}
+  m_LocalRotation: {x: 0.5138036, y: 0.00295625, z: -0.001770302, w: 0.857901}
+  m_LocalPosition: {x: 0, y: 19.58, z: -17.91}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1994886548
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1994886546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowDebugText: 0
+  m_ShowCameraFrustum: 1
+  m_IgnoreTimeScale: 0
+  m_WorldUpOverride: {fileID: 0}
+  m_UpdateMethod: 2
+  m_DefaultBlend:
+    m_Style: 1
+    m_Time: 2
+  m_CustomBlends: {fileID: 0}
+  m_CameraCutEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CameraActivatedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!81 &1994886549
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1994886546}
+  m_Enabled: 1
+--- !u!20 &1994886550
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1994886546}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.01
+  far clip plane: 5000
+  field of view: 40
+  orthographic: 0
+  orthographic size: 10
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
 --- !u!1 &1997279269
 GameObject:
   m_ObjectHideFlags: 3
@@ -2400,8 +2264,8 @@ MonoBehaviour:
   m_LockStageInInspector: 
   m_StreamingVersion: 20170927
   m_Priority: 10
-  m_LookAt: {fileID: 460713636}
-  m_Follow: {fileID: 460713636}
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
   m_CommonLens: 1
   m_Lens:
     FieldOfView: 40
@@ -2464,7 +2328,7 @@ Transform:
   - {fileID: 152169465}
   - {fileID: 810834813}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2117575354
 MonoBehaviour:
@@ -2891,7 +2755,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3341,6 +3205,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerId: 0
+  puzzleObjects: []
   puzzles:
   - {fileID: 2653083718129417507}
   - {fileID: 4276199004436647482}
@@ -3367,7 +3232,7 @@ RectTransform:
   - {fileID: 748654040}
   - {fileID: 9084769516453560123}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}

--- a/Project_Robo/Assets/Scenes/SampleScene.unity
+++ b/Project_Robo/Assets/Scenes/SampleScene.unity
@@ -189,7 +189,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 152169463}
-  m_LocalRotation: {x: 0.44135347, y: 0.00000045164742, z: -0.00000024384153, w: 0.8973334}
+  m_LocalRotation: {x: 0.4413537, y: 0.0000004516883, z: -0.00000024386534, w: 0.89733326}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -203,7 +203,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-6976
+  m_Name: pb_Mesh-20234
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -214,8 +214,8 @@ Mesh:
     firstVertex: 0
     vertexCount: 40
     localAABB:
-      m_Center: {x: 0, y: 0, z: 0}
-      m_Extent: {x: 0, y: 0, z: 0}
+      m_Center: {x: 0.11809921, y: 0.5, z: -0.5}
+      m_Extent: {x: 0.8819008, y: 0.5, z: 0.5}
   m_Shapes:
     vertices: []
     shapes: []
@@ -232,7 +232,7 @@ Mesh:
   m_KeepVertices: 1
   m_KeepIndices: 1
   m_IndexFormat: 0
-  m_IndexBuffer: 0000010002000100030002000800040005000800050006000700080006000d000b000c000d0009000b0009000a000b0011000f00100011000e000f001500130014001500120013001800160017001800190016001b001d001a001b001c001d00200021002200200022001f0022001e001f00250026002700250027002400270023002400
+  m_IndexBuffer: 00000100020001000300020004000500060004000600070008000400070009000a000b0009000c000a000c000d000a000e000f0010000e0011000f001200130014001200150013001600170018001600190017001a001b001c001a001d001b001e001f0020001e0020002100200022002100230024002500230025002600250027002600
   m_VertexData:
     serializedVersion: 3
     m_VertexCount: 40
@@ -294,7 +294,248 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 1920
-    _typelessdata: 0000803f00000000000000000000803f000000000000000000000000000000000000803f000080bf00000000000000000000803f00000000000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf000000000000803f0000803f000000000000803f000000000000000000000000000000000000803f000080bf000000000000803f0000803f0000803f000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf0000803f00000000000000000000000000000000000000000000803f000080bf0000000000000000000080bf00000000000000000000803f000000000000000000000000000000000000803f000080bf0000000000000000000080bf000080bf000000000000803f0000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000080bf0000803f000000000000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000803f000000000000003f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000003f0000803f00000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f000000000000000000000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000000000000000000000000000003f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000003f000000000000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000803f0000803f0000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f0000803f0000000000000000000080bf000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf033c7f3f1e1dc33b0000000000000000000000bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033cff3e1e1d433b808843bffcffff3e000000bfee12d7be1c4624bf1c4624bfb3785d3f72968ebdfd4ffebe000080bf5bba0e3fc1b8e23e000000000000003f000080bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033c7f3fd124013f0000000000000000000000bf43360cbf323056bf000000002466293cb5c8ddbbfffa7fbf000080bf033cff3e1e1d433b00000000000000000000000044360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf0000000000000000000000000000003f0000000044360cbf000000003130563fd1c955bf382e7a3d3ff30bbf000080bf000000002d3dff3e808843bffcffff3e000000bf44360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf5bba0e3fc1b8e23e000000000000003f00000000bdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf000000002d3dff3e000000000000803f00000000000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf000000002d3d7f3f000000000000803f000000bfbdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf033cff3e2500803f808843bffcffff3e000000bff412d7be1b46243f1b46243f9fac4ebf6a6b703dc95116bf000080bf5bba0e3fc1b8e23e000000000000803f000000bf45360cbf3030563f000000006fba05bc1e15afbbe2fc7fbf000080bf033cff3e2500803f000000000000803f000080bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf033c7f3fb461803f000000000000003f000080bf44360cbf00000000313056bfd5b2553fb4678abd34e40bbf000080bf033c7f3fd124013f808843bffcffff3e000000bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf5bba0e3fc1b8e23e000000000000803f00000000000000000000803f000000000000803f0000000000000000000080bf00000000000000000000803f0000803f00000000000000000000803f000000000000803f0000000000000000000080bf0000803f000000000000803f0000803f000080bf000000000000803f000000000000803f0000000000000000000080bf0000803f000080bf000000000000803f000080bf000000000000803f000000000000803f0000000000000000000080bf00000000000080bf000000000000803f000000bf000000000000803f000000000000803f0000000000000000000080bf00000000000000bf0000000000000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000080bf0000803f00000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf000080bf000080bf0000803f000000000000000000000000000080bf00000000000080bf0000000000000000000080bf000080bf0000000000000000000000000000000000000000000080bf00000000000080bf0000000000000000000080bf00000000000000000000000000000000000000bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000000bf
+    _typelessdata: 0000803f00000000000000000000803f000000000000000000000000000000000000803f000080bf00000000000000000000803f00000000000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf000000000000803f0000803f000000000000803f000000000000000000000000000000000000803f000080bf000000000000803f0000803f0000803f000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf0000803f000000000000003f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000003f00000000000000000000000000000000000000000000803f000080bf0000000000000000000080bf00000000000000000000803f000000000000000000000000000000000000803f000080bf0000000000000000000080bf000080bf000000000000803f0000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000080bf0000803f000000000000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000803f0000803f0000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f0000803f000000000000003f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000003f000000000000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000803f0000803f00000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f000000000000000000000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000000000000000000000000000003f000080bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033c7f3fd124013f0000000000000000000000bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033cff3e1e1d433b808843bffcffff3e000000bfee12d7be1c4624bf1c4624bfb3785d3f72968ebdfd4ffebe000080bf5bba0e3fc1b8e23e0000000000000000000080bf000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf033c7f3f1e1dc33b808843bffcffff3e000000bf44360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf5bba0e3fc1b8e23e00000000000000000000000044360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf0000000000000000000000000000003f0000000044360cbf000000003130563fd1c955bf382e7a3d3ff30bbf000080bf000000002d3dff3e0000000000000000000000bf43360cbf323056bf000000002466293cb5c8ddbbfffa7fbf000080bf033cff3e1e1d433b000000000000803f000000bfbdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf033cff3e2500803f000000000000003f00000000bdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf000000002d3dff3e000000000000803f00000000000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf000000002d3d7f3f808843bffcffff3e000000bff412d7be1b46243f1b46243f9fac4ebf6a6b703dc95116bf000080bf5bba0e3fc1b8e23e000000000000803f000080bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf033c7f3fb461803f808843bffcffff3e000000bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf5bba0e3fc1b8e23e000000000000803f000000bf45360cbf3030563f000000006fba05bc1e15afbbe2fc7fbf000080bf033cff3e2500803f000000000000003f000080bf44360cbf00000000313056bfd5b2553fb4678abd34e40bbf000080bf033c7f3fd124013f0000803f0000803f000080bf000000000000803f000000000000803f0000000000000000000080bf0000803f000080bf000000000000803f000080bf000000000000803f000000000000803f0000000000000000000080bf00000000000080bf000000000000803f000000bf000000000000803f000000000000803f0000000000000000000080bf00000000000000bf0000803f0000803f00000000000000000000803f000000000000803f0000000000000000000080bf0000803f00000000000000000000803f00000000000000000000803f000000000000803f0000000000000000000080bf00000000000000000000803f000000000000000000000000000080bf00000000000080bf0000000000000000000080bf000080bf0000000000000000000000000000000000000000000080bf00000000000080bf0000000000000000000080bf00000000000000000000000000000000000000bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000000bf0000803f00000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf000080bf000080bf0000000000000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000080bf
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0.11809921, y: 0.5, z: -0.5}
+    m_Extent: {x: 0.8819008, y: 0.5, z: 0.5}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
+--- !u!1001 &238046360
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 20.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2192275867842323913, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Name
+      value: PuzzleObject (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099232995109567543, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1779681654}
+    - target: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: puzzleID
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: selfObject
+      value: 
+      objectReference: {fileID: 7750490122968491245, guid: 6ad39e84afa0aaf4091e79a3ff2727dd, type: 3}
+    - target: {fileID: 5340211444558257664, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1779681654}
+    - target: {fileID: 6816703050865798000, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1779681654}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+--- !u!43 &300803023
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: pb_Mesh-95490
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 66
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 40
+    localAABB:
+      m_Center: {x: 0.11809921, y: 0.5, z: -0.5}
+      m_Extent: {x: 0.8819008, y: 0.5, z: 0.5}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020001000300020004000500060004000600070008000400070009000a000b0009000c000a000c000d000a000e000f0010000e0011000f001200130014001200150013001600170018001600190017001a001b001c001a001d001b001e001f0020001e0020002100200022002100230024002500230025002600250027002600
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 40
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 40
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 1920
+    _typelessdata: 0000803f00000000000000000000803f000000000000000000000000000000000000803f000080bf00000000000000000000803f00000000000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf000000000000803f0000803f000000000000803f000000000000000000000000000000000000803f000080bf000000000000803f0000803f0000803f000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf0000803f000000000000003f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000003f00000000000000000000000000000000000000000000803f000080bf0000000000000000000080bf00000000000000000000803f000000000000000000000000000000000000803f000080bf0000000000000000000080bf000080bf000000000000803f0000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000080bf0000803f000000000000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000803f0000803f0000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f0000803f000000000000003f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000003f000000000000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000803f0000803f00000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f000000000000000000000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000000000000000000000000000003f000080bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033c7f3fd124013f0000000000000000000000bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033cff3e1e1d433b808843bffcffff3e000000bfee12d7be1c4624bf1c4624bfb3785d3f72968ebdfd4ffebe000080bf5bba0e3fc1b8e23e0000000000000000000080bf000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf033c7f3f1e1dc33b808843bffcffff3e000000bf44360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf5bba0e3fc1b8e23e00000000000000000000000044360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf0000000000000000000000000000003f0000000044360cbf000000003130563fd1c955bf382e7a3d3ff30bbf000080bf000000002d3dff3e0000000000000000000000bf43360cbf323056bf000000002466293cb5c8ddbbfffa7fbf000080bf033cff3e1e1d433b000000000000803f000000bfbdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf033cff3e2500803f000000000000003f00000000bdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf000000002d3dff3e000000000000803f00000000000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf000000002d3d7f3f808843bffcffff3e000000bff412d7be1b46243f1b46243f9fac4ebf6a6b703dc95116bf000080bf5bba0e3fc1b8e23e000000000000803f000080bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf033c7f3fb461803f808843bffcffff3e000000bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf5bba0e3fc1b8e23e000000000000803f000000bf45360cbf3030563f000000006fba05bc1e15afbbe2fc7fbf000080bf033cff3e2500803f000000000000003f000080bf44360cbf00000000313056bfd5b2553fb4678abd34e40bbf000080bf033c7f3fd124013f0000803f0000803f000080bf000000000000803f000000000000803f0000000000000000000080bf0000803f000080bf000000000000803f000080bf000000000000803f000000000000803f0000000000000000000080bf00000000000080bf000000000000803f000000bf000000000000803f000000000000803f0000000000000000000080bf00000000000000bf0000803f0000803f00000000000000000000803f000000000000803f0000000000000000000080bf0000803f00000000000000000000803f00000000000000000000803f000000000000803f0000000000000000000080bf00000000000000000000803f000000000000000000000000000080bf00000000000080bf0000000000000000000080bf000080bf0000000000000000000000000000000000000000000080bf00000000000080bf0000000000000000000080bf00000000000000000000000000000000000000bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000000bf0000803f00000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf000080bf000080bf0000000000000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000080bf
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -432,6 +673,10 @@ PrefabInstance:
       propertyPath: cursor
       value: 
       objectReference: {fileID: 132125516}
+    - target: {fileID: 7591369884324081962, guid: c0d1451055e4b8b4e985c10808bcc963, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -931
+      objectReference: {fileID: 0}
     - target: {fileID: 7649058118443604295, guid: c0d1451055e4b8b4e985c10808bcc963, type: 3}
       propertyPath: cursor
       value: 
@@ -452,6 +697,30 @@ PrefabInstance:
       propertyPath: puzzleNearText
       value: 
       objectReference: {fileID: 1955421834}
+    - target: {fileID: 9084769514669396344, guid: c0d1451055e4b8b4e985c10808bcc963, type: 3}
+      propertyPath: puzzleObjects.Array.data[0]
+      value: 
+      objectReference: {fileID: 1077292699}
+    - target: {fileID: 9084769514669396344, guid: c0d1451055e4b8b4e985c10808bcc963, type: 3}
+      propertyPath: puzzleObjects.Array.data[1]
+      value: 
+      objectReference: {fileID: 557019394}
+    - target: {fileID: 9084769514669396344, guid: c0d1451055e4b8b4e985c10808bcc963, type: 3}
+      propertyPath: puzzleObjects.Array.data[2]
+      value: 
+      objectReference: {fileID: 1229646421}
+    - target: {fileID: 9084769514669396344, guid: c0d1451055e4b8b4e985c10808bcc963, type: 3}
+      propertyPath: puzzleObjects.Array.data[3]
+      value: 
+      objectReference: {fileID: 1514884402}
+    - target: {fileID: 9084769514669396344, guid: c0d1451055e4b8b4e985c10808bcc963, type: 3}
+      propertyPath: puzzleObjects.Array.data[4]
+      value: 
+      objectReference: {fileID: 2096941972}
+    - target: {fileID: 9084769514669396344, guid: c0d1451055e4b8b4e985c10808bcc963, type: 3}
+      propertyPath: puzzleObjects.Array.data[5]
+      value: 
+      objectReference: {fileID: 614655694}
     - target: {fileID: 9084769514669396345, guid: c0d1451055e4b8b4e985c10808bcc963, type: 3}
       propertyPath: m_Pivot.x
       value: 0
@@ -640,7 +909,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh19860
+  m_Name: pb_Mesh31038
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -798,6 +1067,107 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!114 &557019394 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+  m_PrefabInstance: {fileID: 1724570460}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f44ab303a3224940b75b763d159399b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &614655694 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+  m_PrefabInstance: {fileID: 1884854515}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f44ab303a3224940b75b763d159399b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &671314916
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 671314917}
+  - component: {fileID: 671314919}
+  - component: {fileID: 671314918}
+  m_Layer: 5
+  m_Name: DummyText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &671314917
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 671314916}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2000238084}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 880, y: 440}
+  m_SizeDelta: {x: 600, y: 50}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &671314918
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 671314916}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 50
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 5
+    m_MaxSize: 50
+    m_Alignment: 2
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: Your Current Tasks
+--- !u!222 &671314919
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 671314916}
+  m_CullTransparentMesh: 1
 --- !u!1 &674499911
 GameObject:
   m_ObjectHideFlags: 0
@@ -1105,8 +1475,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 674499911}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -12.19, y: -3.25, z: 12.05}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: -12.19, y: -3.25, z: 26.1}
+  m_LocalScale: {x: 1, y: 1, z: 1.567}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -1204,6 +1574,83 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1001 &708343084
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2192275867842323913, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Name
+      value: PuzzleObject (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099232995109567543, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 300803023}
+    - target: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: puzzleID
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: selfObject
+      value: 
+      objectReference: {fileID: 7750490122968491245, guid: 6ad39e84afa0aaf4091e79a3ff2727dd, type: 3}
+    - target: {fileID: 5340211444558257664, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 300803023}
+    - target: {fileID: 6816703050865798000, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 300803023}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
 --- !u!1 &810834811
 GameObject:
   m_ObjectHideFlags: 3
@@ -1259,7 +1706,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 810834811}
-  m_LocalRotation: {x: 0.4250238, y: 0.00000039161117, z: -0.00000018049508, w: 0.90518224}
+  m_LocalRotation: {x: 0.42502403, y: 0.0000003916111, z: -0.00000018048405, w: 0.9051821}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1322,7 +1769,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 825130883}
-  m_LocalRotation: {x: 0.5138033, y: 0.00295806, z: -0.0017711773, w: 0.85790116}
+  m_LocalRotation: {x: 0.5138034, y: 0.0029583492, z: -0.0017714065, w: 0.8579011}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1412,7 +1859,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
-  m_LocalRotation: {x: 0.5138034, y: 0.002958362, z: -0.0017717852, w: 0.85790104}
+  m_LocalRotation: {x: 0.5138034, y: 0.0029546528, z: -0.0017695638, w: 0.8579011}
   m_LocalPosition: {x: 0.4472171, y: 19.304646, z: -18.91097}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -1587,6 +2034,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fb09df0ac017da342b4cf442b5df4126, type: 3}
+--- !u!114 &1077292699 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+  m_PrefabInstance: {fileID: 1857443468}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f44ab303a3224940b75b763d159399b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1124911442
 GameObject:
   m_ObjectHideFlags: 3
@@ -1697,6 +2155,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1229646421 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+  m_PrefabInstance: {fileID: 238046360}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f44ab303a3224940b75b763d159399b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1270175431
@@ -1811,6 +2280,750 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!43 &1272572205
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: pb_Mesh-95726
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 66
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 40
+    localAABB:
+      m_Center: {x: 0.11809921, y: 0.5, z: -0.5}
+      m_Extent: {x: 0.8819008, y: 0.5, z: 0.5}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020001000300020004000500060004000600070008000400070009000a000b0009000c000a000c000d000a000e000f0010000e0011000f001200130014001200150013001600170018001600190017001a001b001c001a001d001b001e001f0020001e0020002100200022002100230024002500230025002600250027002600
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 40
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 40
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 1920
+    _typelessdata: 0000803f00000000000000000000803f000000000000000000000000000000000000803f000080bf00000000000000000000803f00000000000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf000000000000803f0000803f000000000000803f000000000000000000000000000000000000803f000080bf000000000000803f0000803f0000803f000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf0000803f000000000000003f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000003f00000000000000000000000000000000000000000000803f000080bf0000000000000000000080bf00000000000000000000803f000000000000000000000000000000000000803f000080bf0000000000000000000080bf000080bf000000000000803f0000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000080bf0000803f000000000000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000803f0000803f0000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f0000803f000000000000003f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000003f000000000000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000803f0000803f00000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f000000000000000000000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000000000000000000000000000003f000080bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033c7f3fd124013f0000000000000000000000bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033cff3e1e1d433b808843bffcffff3e000000bfee12d7be1c4624bf1c4624bfb3785d3f72968ebdfd4ffebe000080bf5bba0e3fc1b8e23e0000000000000000000080bf000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf033c7f3f1e1dc33b808843bffcffff3e000000bf44360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf5bba0e3fc1b8e23e00000000000000000000000044360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf0000000000000000000000000000003f0000000044360cbf000000003130563fd1c955bf382e7a3d3ff30bbf000080bf000000002d3dff3e0000000000000000000000bf43360cbf323056bf000000002466293cb5c8ddbbfffa7fbf000080bf033cff3e1e1d433b000000000000803f000000bfbdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf033cff3e2500803f000000000000003f00000000bdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf000000002d3dff3e000000000000803f00000000000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf000000002d3d7f3f808843bffcffff3e000000bff412d7be1b46243f1b46243f9fac4ebf6a6b703dc95116bf000080bf5bba0e3fc1b8e23e000000000000803f000080bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf033c7f3fb461803f808843bffcffff3e000000bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf5bba0e3fc1b8e23e000000000000803f000000bf45360cbf3030563f000000006fba05bc1e15afbbe2fc7fbf000080bf033cff3e2500803f000000000000003f000080bf44360cbf00000000313056bfd5b2553fb4678abd34e40bbf000080bf033c7f3fd124013f0000803f0000803f000080bf000000000000803f000000000000803f0000000000000000000080bf0000803f000080bf000000000000803f000080bf000000000000803f000000000000803f0000000000000000000080bf00000000000080bf000000000000803f000000bf000000000000803f000000000000803f0000000000000000000080bf00000000000000bf0000803f0000803f00000000000000000000803f000000000000803f0000000000000000000080bf0000803f00000000000000000000803f00000000000000000000803f000000000000803f0000000000000000000080bf00000000000000000000803f000000000000000000000000000080bf00000000000080bf0000000000000000000080bf000080bf0000000000000000000000000000000000000000000080bf00000000000080bf0000000000000000000080bf00000000000000000000000000000000000000bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000000bf0000803f00000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf000080bf000080bf0000000000000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000080bf
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0.11809921, y: 0.5, z: -0.5}
+    m_Extent: {x: 0.8819008, y: 0.5, z: 0.5}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1324423824
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: pb_Mesh-92940
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 66
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 40
+    localAABB:
+      m_Center: {x: 0.11809921, y: 0.5, z: -0.5}
+      m_Extent: {x: 0.8819008, y: 0.5, z: 0.5}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020001000300020004000500060004000600070008000400070009000a000b0009000c000a000c000d000a000e000f0010000e0011000f001200130014001200150013001600170018001600190017001a001b001c001a001d001b001e001f0020001e0020002100200022002100230024002500230025002600250027002600
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 40
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 40
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 1920
+    _typelessdata: 0000803f00000000000000000000803f000000000000000000000000000000000000803f000080bf00000000000000000000803f00000000000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf000000000000803f0000803f000000000000803f000000000000000000000000000000000000803f000080bf000000000000803f0000803f0000803f000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf0000803f000000000000003f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000003f00000000000000000000000000000000000000000000803f000080bf0000000000000000000080bf00000000000000000000803f000000000000000000000000000000000000803f000080bf0000000000000000000080bf000080bf000000000000803f0000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000080bf0000803f000000000000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000803f0000803f0000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f0000803f000000000000003f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000003f000000000000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000803f0000803f00000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f000000000000000000000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000000000000000000000000000003f000080bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033c7f3fd124013f0000000000000000000000bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033cff3e1e1d433b808843bffcffff3e000000bfee12d7be1c4624bf1c4624bfb3785d3f72968ebdfd4ffebe000080bf5bba0e3fc1b8e23e0000000000000000000080bf000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf033c7f3f1e1dc33b808843bffcffff3e000000bf44360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf5bba0e3fc1b8e23e00000000000000000000000044360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf0000000000000000000000000000003f0000000044360cbf000000003130563fd1c955bf382e7a3d3ff30bbf000080bf000000002d3dff3e0000000000000000000000bf43360cbf323056bf000000002466293cb5c8ddbbfffa7fbf000080bf033cff3e1e1d433b000000000000803f000000bfbdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf033cff3e2500803f000000000000003f00000000bdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf000000002d3dff3e000000000000803f00000000000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf000000002d3d7f3f808843bffcffff3e000000bff412d7be1b46243f1b46243f9fac4ebf6a6b703dc95116bf000080bf5bba0e3fc1b8e23e000000000000803f000080bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf033c7f3fb461803f808843bffcffff3e000000bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf5bba0e3fc1b8e23e000000000000803f000000bf45360cbf3030563f000000006fba05bc1e15afbbe2fc7fbf000080bf033cff3e2500803f000000000000003f000080bf44360cbf00000000313056bfd5b2553fb4678abd34e40bbf000080bf033c7f3fd124013f0000803f0000803f000080bf000000000000803f000000000000803f0000000000000000000080bf0000803f000080bf000000000000803f000080bf000000000000803f000000000000803f0000000000000000000080bf00000000000080bf000000000000803f000000bf000000000000803f000000000000803f0000000000000000000080bf00000000000000bf0000803f0000803f00000000000000000000803f000000000000803f0000000000000000000080bf0000803f00000000000000000000803f00000000000000000000803f000000000000803f0000000000000000000080bf00000000000000000000803f000000000000000000000000000080bf00000000000080bf0000000000000000000080bf000080bf0000000000000000000000000000000000000000000080bf00000000000080bf0000000000000000000080bf00000000000000000000000000000000000000bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000000bf0000803f00000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf000080bf000080bf0000000000000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000080bf
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0.11809921, y: 0.5, z: -0.5}
+    m_Extent: {x: 0.8819008, y: 0.5, z: 0.5}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
+--- !u!114 &1514884402 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+  m_PrefabInstance: {fileID: 1924216257}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f44ab303a3224940b75b763d159399b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!43 &1534608779
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: pb_Mesh-94996
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 66
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 40
+    localAABB:
+      m_Center: {x: 0.11809921, y: 0.5, z: -0.5}
+      m_Extent: {x: 0.8819008, y: 0.5, z: 0.5}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020001000300020004000500060004000600070008000400070009000a000b0009000c000a000c000d000a000e000f0010000e0011000f001200130014001200150013001600170018001600190017001a001b001c001a001d001b001e001f0020001e0020002100200022002100230024002500230025002600250027002600
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 40
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 40
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 1920
+    _typelessdata: 0000803f00000000000000000000803f000000000000000000000000000000000000803f000080bf00000000000000000000803f00000000000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf000000000000803f0000803f000000000000803f000000000000000000000000000000000000803f000080bf000000000000803f0000803f0000803f000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf0000803f000000000000003f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000003f00000000000000000000000000000000000000000000803f000080bf0000000000000000000080bf00000000000000000000803f000000000000000000000000000000000000803f000080bf0000000000000000000080bf000080bf000000000000803f0000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000080bf0000803f000000000000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000803f0000803f0000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f0000803f000000000000003f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000003f000000000000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000803f0000803f00000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f000000000000000000000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000000000000000000000000000003f000080bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033c7f3fd124013f0000000000000000000000bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033cff3e1e1d433b808843bffcffff3e000000bfee12d7be1c4624bf1c4624bfb3785d3f72968ebdfd4ffebe000080bf5bba0e3fc1b8e23e0000000000000000000080bf000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf033c7f3f1e1dc33b808843bffcffff3e000000bf44360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf5bba0e3fc1b8e23e00000000000000000000000044360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf0000000000000000000000000000003f0000000044360cbf000000003130563fd1c955bf382e7a3d3ff30bbf000080bf000000002d3dff3e0000000000000000000000bf43360cbf323056bf000000002466293cb5c8ddbbfffa7fbf000080bf033cff3e1e1d433b000000000000803f000000bfbdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf033cff3e2500803f000000000000003f00000000bdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf000000002d3dff3e000000000000803f00000000000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf000000002d3d7f3f808843bffcffff3e000000bff412d7be1b46243f1b46243f9fac4ebf6a6b703dc95116bf000080bf5bba0e3fc1b8e23e000000000000803f000080bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf033c7f3fb461803f808843bffcffff3e000000bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf5bba0e3fc1b8e23e000000000000803f000000bf45360cbf3030563f000000006fba05bc1e15afbbe2fc7fbf000080bf033cff3e2500803f000000000000003f000080bf44360cbf00000000313056bfd5b2553fb4678abd34e40bbf000080bf033c7f3fd124013f0000803f0000803f000080bf000000000000803f000000000000803f0000000000000000000080bf0000803f000080bf000000000000803f000080bf000000000000803f000000000000803f0000000000000000000080bf00000000000080bf000000000000803f000000bf000000000000803f000000000000803f0000000000000000000080bf00000000000000bf0000803f0000803f00000000000000000000803f000000000000803f0000000000000000000080bf0000803f00000000000000000000803f00000000000000000000803f000000000000803f0000000000000000000080bf00000000000000000000803f000000000000000000000000000080bf00000000000080bf0000000000000000000080bf000080bf0000000000000000000000000000000000000000000080bf00000000000080bf0000000000000000000080bf00000000000000000000000000000000000000bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000000bf0000803f00000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf000080bf000080bf0000000000000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000080bf
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0.11809921, y: 0.5, z: -0.5}
+    m_Extent: {x: 0.8819008, y: 0.5, z: 0.5}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
+--- !u!1001 &1724570460
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.96
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2192275867842323913, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Name
+      value: PuzzleObject (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099232995109567543, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1324423824}
+    - target: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: puzzleID
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: selfObject
+      value: 
+      objectReference: {fileID: 7750490122968491245, guid: 6ad39e84afa0aaf4091e79a3ff2727dd, type: 3}
+    - target: {fileID: 5340211444558257664, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1324423824}
+    - target: {fileID: 6816703050865798000, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1324423824}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+--- !u!43 &1779681654
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: pb_Mesh-93912
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 66
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 40
+    localAABB:
+      m_Center: {x: 0.11809921, y: 0.5, z: -0.5}
+      m_Extent: {x: 0.8819008, y: 0.5, z: 0.5}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020001000300020004000500060004000600070008000400070009000a000b0009000c000a000c000d000a000e000f0010000e0011000f001200130014001200150013001600170018001600190017001a001b001c001a001d001b001e001f0020001e0020002100200022002100230024002500230025002600250027002600
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 40
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 40
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 1920
+    _typelessdata: 0000803f00000000000000000000803f000000000000000000000000000000000000803f000080bf00000000000000000000803f00000000000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf000000000000803f0000803f000000000000803f000000000000000000000000000000000000803f000080bf000000000000803f0000803f0000803f000080bf0000803f000000000000000000000000000000000000803f000080bf000080bf0000803f000000000000003f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000003f00000000000000000000000000000000000000000000803f000080bf0000000000000000000080bf00000000000000000000803f000000000000000000000000000000000000803f000080bf0000000000000000000080bf000080bf000000000000803f0000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000080bf0000803f000000000000803f0000000000000000000000000000803f000080bf0000000000000000000080bf000000000000803f0000803f0000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f0000803f000000000000003f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000003f000000000000803f000080bf0000000000000000000080bf0000803f0000000000000000000080bf000000000000803f0000803f00000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000803f000000000000000000000000000080bf0000000000000000000080bf0000803f0000000000000000000080bf0000000000000000000000000000003f000080bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033c7f3fd124013f0000000000000000000000bfbcc435bf1c46a4be1c46a4bea097ef3ee6f42bbe711e5ebf000080bf033cff3e1e1d433b808843bffcffff3e000000bfee12d7be1c4624bf1c4624bfb3785d3f72968ebdfd4ffebe000080bf5bba0e3fc1b8e23e0000000000000000000080bf000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf033c7f3f1e1dc33b808843bffcffff3e000000bf44360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf5bba0e3fc1b8e23e00000000000000000000000044360cbf3230d6be3130d63e11421dbf6f027b3c75f749bf000080bf0000000000000000000000000000003f0000000044360cbf000000003130563fd1c955bf382e7a3d3ff30bbf000080bf000000002d3dff3e0000000000000000000000bf43360cbf323056bf000000002466293cb5c8ddbbfffa7fbf000080bf033cff3e1e1d433b000000000000803f000000bfbdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf033cff3e2500803f000000000000003f00000000bdc435bf1b46a43e1b46a43e5917d7bebd26b8bc383e68bf000080bf000000002d3dff3e000000000000803f00000000000080bf00000000000000000000000008b1c3bbd5fe7fbf000080bf000000002d3d7f3f808843bffcffff3e000000bff412d7be1b46243f1b46243f9fac4ebf6a6b703dc95116bf000080bf5bba0e3fc1b8e23e000000000000803f000080bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf033c7f3fb461803f808843bffcffff3e000000bf44360cbf3030d63e3130d6be4708183f13d3d9bc9ada4dbf000080bf5bba0e3fc1b8e23e000000000000803f000000bf45360cbf3030563f000000006fba05bc1e15afbbe2fc7fbf000080bf033cff3e2500803f000000000000003f000080bf44360cbf00000000313056bfd5b2553fb4678abd34e40bbf000080bf033c7f3fd124013f0000803f0000803f000080bf000000000000803f000000000000803f0000000000000000000080bf0000803f000080bf000000000000803f000080bf000000000000803f000000000000803f0000000000000000000080bf00000000000080bf000000000000803f000000bf000000000000803f000000000000803f0000000000000000000080bf00000000000000bf0000803f0000803f00000000000000000000803f000000000000803f0000000000000000000080bf0000803f00000000000000000000803f00000000000000000000803f000000000000803f0000000000000000000080bf00000000000000000000803f000000000000000000000000000080bf00000000000080bf0000000000000000000080bf000080bf0000000000000000000000000000000000000000000080bf00000000000080bf0000000000000000000080bf00000000000000000000000000000000000000bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000000bf0000803f00000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf000080bf000080bf0000000000000000000080bf00000000000080bf00000000000080bf0000000000000000000080bf00000000000080bf
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0.11809921, y: 0.5, z: -0.5}
+    m_Extent: {x: 0.8819008, y: 0.5, z: 0.5}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1001 &1857443468
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1820,11 +3033,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 15.4
+      value: -11.96
       objectReference: {fileID: 0}
     - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_LocalPosition.y
@@ -1832,7 +3045,84 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -2.6
+      value: -9.22
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2192275867842323913, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Name
+      value: PuzzleObject
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099232995109567543, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 157793543}
+    - target: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: puzzleID
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: selfObject
+      value: 
+      objectReference: {fileID: 7750490122968491245, guid: 6ad39e84afa0aaf4091e79a3ff2727dd, type: 3}
+    - target: {fileID: 5340211444558257664, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 157793543}
+    - target: {fileID: 6816703050865798000, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 157793543}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+--- !u!1001 &1884854515
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.51
       objectReference: {fileID: 0}
     - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1864,12 +3154,89 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2192275867842323913, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_Name
-      value: PuzzleObject
+      value: PuzzleObject (5)
       objectReference: {fileID: 0}
     - target: {fileID: 4099232995109567543, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 157793543}
+      objectReference: {fileID: 1272572205}
+    - target: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: puzzleID
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: selfObject
+      value: 
+      objectReference: {fileID: 7750490122968491245, guid: 6ad39e84afa0aaf4091e79a3ff2727dd, type: 3}
+    - target: {fileID: 5340211444558257664, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1272572205}
+    - target: {fileID: 6816703050865798000, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1272572205}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+--- !u!1001 &1924216257
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 20.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35519359056995997, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2192275867842323913, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Name
+      value: PuzzleObject (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099232995109567543, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1534608779}
     - target: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: puzzleID
       value: 3
@@ -1881,11 +3248,11 @@ PrefabInstance:
     - target: {fileID: 5340211444558257664, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 157793543}
+      objectReference: {fileID: 1534608779}
     - target: {fileID: 6816703050865798000, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 157793543}
+      objectReference: {fileID: 1534608779}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
 --- !u!114 &1955421834 stripped
@@ -2009,6 +3376,22 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &2000238084 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7591369884324081962, guid: c0d1451055e4b8b4e985c10808bcc963, type: 3}
+  m_PrefabInstance: {fileID: 300940384}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2096941972 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4724689960618247402, guid: dfee5ae93dc5600498ade1c042d49d70, type: 3}
+  m_PrefabInstance: {fileID: 708343084}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f44ab303a3224940b75b763d159399b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &2117575351
@@ -2183,7 +3566,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 4282831768928739200, guid: d7f17621c30525b429ad23480d633e51, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Project_Robo/Assets/Scripts/Player/PuzzleInteraction.cs
+++ b/Project_Robo/Assets/Scripts/Player/PuzzleInteraction.cs
@@ -40,12 +40,14 @@ public class PuzzleInteraction : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        /*
         if (player.GetButtonDown("ShowPuzzle"))
         {
             UI.togglePuzzle();
             playerMovement.isInAMenu = true;    // Added to prevent player movement when the puzzel UI is showing
 
         }
+        */
 
         if (player.GetButtonDown("Exit"))
         {
@@ -53,11 +55,13 @@ public class PuzzleInteraction : MonoBehaviour
             playerMovement.isInAMenu = false;   // Added to re-enable the player movement
         }
 
+        /*
         if (player.GetButtonDown("PuzzlePrevious"))
             UI.HandlePuzzleSwitching("previous");
 
         if (player.GetButtonDown("PuzzleNext"))
             UI.HandlePuzzleSwitching("next");
+            */
     }
 
 

--- a/Project_Robo/Assets/Scripts/PuzzleCode/PuzzleObject.cs
+++ b/Project_Robo/Assets/Scripts/PuzzleCode/PuzzleObject.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 
 
@@ -9,13 +10,16 @@ public class PuzzleObject : MonoBehaviour
 
     [SerializeField] private GameObject selfObject;
     [SerializeField] private GameObject placementCube;
+    [SerializeField] private Text taskTextPrefab;
     [SerializeField] public int puzzleID;
+    [SerializeField] public string taskName = "Observe the Monitor";
+    public GameObject taskHolder;
+    public Text taskText;
 
     public bool cleared = false;
     public bool nearThis = false;
 
     private PuzzleUI UI = null;
-    public BoxCollider collider = null;
 
 
 
@@ -33,13 +37,27 @@ public class PuzzleObject : MonoBehaviour
         {
             Destroy(placementCube.gameObject);
         }
+
+        taskHolder = GameObject.FindGameObjectWithTag("TaskList");
+
+        if (taskHolder != null)
+        {
+            taskText = Instantiate(taskTextPrefab, taskHolder.transform);
+
+            taskText.rectTransform.Translate(new Vector3(0, -60 * (puzzleID + 1), 0));
+
+            taskText.text = taskName;
+        }
     }
 
     // Update is called once per frame
     void Update()
     {
         if (UI.puzzles[puzzleID].GetComponent<PuzzleMaster>().isComplete)
+        {
             cleared = true;
+            taskText.color = Color.green;
+        }
         else
             cleared = false;
     }

--- a/Project_Robo/Assets/Scripts/PuzzleCode/PuzzleUI.cs
+++ b/Project_Robo/Assets/Scripts/PuzzleCode/PuzzleUI.cs
@@ -26,6 +26,7 @@ public class PuzzleUI : MonoBehaviour
     }
     #endregion
 
+    [SerializeField] public List<PuzzleObject> puzzleObjects;
     [SerializeField] public List<GameObject> puzzles;
     public int currentPuzzle = 0;
     [SerializeField] public GameObject holder;
@@ -87,6 +88,26 @@ public class PuzzleUI : MonoBehaviour
     {
         if (holder.activeSelf)
             holder.SetActive(false);;
+    }
+
+    public void UpdateTaskColor(PuzzleMaster solved)
+    {
+        int id = -1;
+
+        for (int i = 0; i < puzzles.Count; i++)
+        {
+            if (puzzles[i] == solved)
+                id = i;
+        }
+
+        if (id != -1)
+        {
+            for (int i = 0; i < puzzleObjects.Count; i++)
+            {
+                if (puzzleObjects[i].puzzleID == id)
+                    puzzleObjects[i].taskText.color = new Color(100, 255, 100);
+            }
+        }
     }
 
     public void HandlePuzzleSwitching(string direction)

--- a/Project_Robo/ProjectSettings/TagManager.asset
+++ b/Project_Robo/ProjectSettings/TagManager.asset
@@ -6,6 +6,7 @@ TagManager:
   tags:
   - Moveable Node
   - Goal Node
+  - TaskList
   layers:
   - Default
   - TransparentFX

--- a/Project_Robo/UserSettings/EditorUserSettings.asset
+++ b/Project_Robo/UserSettings/EditorUserSettings.asset
@@ -5,6 +5,12 @@ EditorUserSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 4
   m_ConfigSettings:
+    RecentlyUsedScenePath-0:
+      value: 22424703114646680e0b0227036c6f050c0d142f1f2b233e2867083debf42d
+      flags: 0
+    RecentlyUsedScenePath-1:
+      value: 22424703114646680e0b0227036c6c111b07142f1f2b233e2867083debf42d
+      flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650
       flags: 0


### PR DESCRIPTION
Added a task list to the right side of the screen that is populated by PuzzleObjects in the scene, each with their own text blurb. When the puzzle connected to that PuzzleObject has been solved, it's related object in the list turns green.

The taskList itself is included in an updated version of the PuzzleReadyCanvas Prefab and has been given the new tag of TaskList. There is also a new PuzzleObjectExampleText Prefab that the PuzzleObject Prefab has been updated to include. In order for this to work, there have been changes to the PuzzleInteraction, PuzzleObject, and PuzzleUI scripts. This update also added more PuzzleObjects to the Sample Scene for testing purposes, as well as disabling the debug ShowPuzzle, PuzzleNext and PuzzlePrevious commands.